### PR TITLE
Fix ssl

### DIFF
--- a/lib/yubikey/otp_verify.rb
+++ b/lib/yubikey/otp_verify.rb
@@ -31,7 +31,6 @@ module Yubikey
 
       http.use_ssl = true
       http.verify_depth = 2
-      http.enable_post_connection_check = true
       http.verify_mode = OpenSSL::SSL::VERIFY_PEER
       
       req = Net::HTTP::Get.new(uri.request_uri)

--- a/lib/yubikey/otp_verify.rb
+++ b/lib/yubikey/otp_verify.rb
@@ -31,7 +31,7 @@ module Yubikey
 
       http.use_ssl = true
       http.verify_depth = 2
-      https.enable_post_connection_check = true
+      http.enable_post_connection_check = true
       http.verify_mode = OpenSSL::SSL::VERIFY_PEER
       
       req = Net::HTTP::Get.new(uri.request_uri)

--- a/lib/yubikey/otp_verify.rb
+++ b/lib/yubikey/otp_verify.rb
@@ -28,8 +28,11 @@ module Yubikey
       uri.query = query
       
       http = Net::HTTP.new(uri.host, uri.port)
+
       http.use_ssl = true
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      http.verify_depth = 2
+      https.enable_post_connection_check = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_PEER
       
       req = Net::HTTP::Get.new(uri.request_uri)
       result = http.request(req).body

--- a/yubikey.gemspec
+++ b/yubikey.gemspec
@@ -51,11 +51,11 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::RubyGemsVersion) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<crypt19>, [">= 0"])
+      s.add_runtime_dependency(%q<crypt19-rb>, [">= 0"])
     else
-      s.add_dependency(%q<crypt19>, [">= 0"])
+      s.add_dependency(%q<crypt19-rb>, [">= 0"])
     end
   else
-    s.add_dependency(%q<crypt19>, [">= 0"])
+    s.add_dependency(%q<crypt19-rb>, [">= 0"])
   end
 end


### PR DESCRIPTION
Makes me sad that (a) a security-focused gem doesn't verify its peers, and (b) it relies on a gem that doesn't exist.  So I fixed it. crypt19-rb is a clone of crypt19.

Tested locally.  Happy to make any requested changes.

Please don't let this pull request sit for months without response.
