### PR TITLE
run bundle, and re-order to check for junk first

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    yubikey (1.3.0)
+    yubikey (1.3.1)
 
 GEM
   remote: http://www.rubygems.org/

--- a/lib/yubikey/otp.rb
+++ b/lib/yubikey/otp.rb
@@ -22,16 +22,14 @@ class Yubikey::OTP
   # [+otp+] ModHex encoded Yubikey OTP (at least 32 characters)
   # [+key+] 32-character hex AES key
   def initialize(otp, key)
+    raise InvalidOTPError, 'OTP must be at least 32 characters of modhex' unless otp.modhex? && otp.length >= 32
+    raise InvalidKeyError, 'Key must be 32 hex characters' unless key.hex? && key.length == 32
 
     # Get the public ID first
     @public_id = otp[0, 12]
 
     # Strip prefix so otp will decode (following from yubico-c library)
     otp = otp[-32,32] if otp.length > 32
-
-    raise InvalidOTPError, 'OTP must be at least 32 characters of modhex' unless otp.modhex? && otp.length >= 32
-    raise InvalidKeyError, 'Key must be 32 hex characters' unless key.hex? && key.length == 32
-
 
     @token = Yubikey::ModHex.decode(otp[-32,32])
     @aes_key = key.to_bin


### PR DESCRIPTION
This is the net effect of running bundle (which bumped the version from 1.3.0 to 1.3.1).

It also re-orders the usage of the otp parameter and raising on garbage, so the sanity check is run first.
