### PR TITLE
Support for Local Verifier/API Endpoint

### DIFF
--- a/lib/yubikey/configuration.rb
+++ b/lib/yubikey/configuration.rb
@@ -4,9 +4,13 @@ module Yubikey
     # An array of valid keys in the options hash when configuring a Yubikey::OTP::Verify
     VALID_OPTIONS_KEYS = [
       :api_id,
+      :url,
       :api_key,
       :certificate_chain,
     ].freeze
+
+    # By default, we want to point to Yubicloud
+    DEFAULT_API_URL           = 'https://api.yubico.com/wsapi/2.0/'
 
     # By default, don't have an api_id
     DEFAULT_API_ID            = nil
@@ -40,6 +44,7 @@ module Yubikey
     # Reset all configuration options to defaults
     def reset
       self.api_id            = DEFAULT_API_ID
+      self.url               = DEFAULT_API_URL
       self.api_key           = DEFAULT_API_KEY
       self.certificate_chain = DEFAULT_CERTIFICATE_CHAIN
     end

--- a/lib/yubikey/otp_verify.rb
+++ b/lib/yubikey/otp_verify.rb
@@ -5,8 +5,6 @@ require "uri"
 
 module Yubikey
   
-  API_URL = 'https://api.yubico.com/wsapi/2.0/'
-
   class OTP::Verify
     # The raw status from the Yubico server
     attr_reader :status
@@ -19,7 +17,7 @@ module Yubikey
       raise(ArgumentError, "Must supply API Key") if @api_key.nil?
       raise(ArgumentError, "Must supply OTP") if args[:otp].nil?
 
-      @url = args[:url] || API_URL
+      @url = args[:url] || Yubikey.url
       @nonce = args[:nonce] || OTP::Verify.generate_nonce(32)
       
       @certificate_chain = args[:certificate_chain] || Yubikey.certificate_chain


### PR DESCRIPTION
This is a work in progress, but I wanted to get your thoughts on this. I'm using a YubiHSM and my own internal verification server. I figured that rather than keep a fork of the gem in my vendor/ directory of my app, I'd try to contribute back.

One thing I'm not entirely sure about is how to write a test for that particular situation. I mean, it _should_ receive a response back that matches what the YubiCloud gives (see Yubico/yubikey-val), but admittedly I'm not 100% on what i'm doing with regard to test design.

I'm happy to do some more testing on my own, but I imagine that this approach wouldn't break things for the majority of folks using YubiCloud for verification. Good idea? Bad idea?
