### PR TITLE
Added chain.pem to gemspec

### DIFF
--- a/yubikey.gemspec
+++ b/yubikey.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
       "lib/yubikey/modhex.rb",
       "lib/yubikey/otp.rb",
       "lib/yubikey/otp_verify.rb",
+      "lib/cert/chain.pem",
       "spec/hex_spec.rb",
       "spec/spec_helper.rb"
   ]


### PR DESCRIPTION
lib/cert/chain.pem was missing from the gemspec, causing the examples
in the README to fail.

Fixes #17
