### PR TITLE
Parse the otp from the api response

### DIFF
--- a/lib/yubikey/otp_verify.rb
+++ b/lib/yubikey/otp_verify.rb
@@ -56,7 +56,6 @@ module Yubikey
       result = http.request(req).body
 
       @status = result[/status=(.*)$/,1].strip
-      @otp = result[/otp=(.*)$/,1].strip
       
       if @status == 'BAD_OTP' || @status == 'BACKEND_ERROR'
         raise OTP::InvalidOTPError, "Received error: #{@status}"
@@ -66,6 +65,8 @@ module Yubikey
         @status = 'BAD_RESPONSE'
         return
       end
+
+      @otp = result[/otp=(.*)$/,1].strip
     end
 
     def verify_response(result)

--- a/lib/yubikey/otp_verify.rb
+++ b/lib/yubikey/otp_verify.rb
@@ -35,6 +35,10 @@ module Yubikey
       @status == 'REPLAYED_OTP'
     end
     
+    def otp
+      @otp
+    end
+
     private
     
     def verify(args)
@@ -52,6 +56,7 @@ module Yubikey
       result = http.request(req).body
 
       @status = result[/status=(.*)$/,1].strip
+      @otp = result[/otp=(.*)$/,1].strip
       
       if @status == 'BAD_OTP' || @status == 'BACKEND_ERROR'
         raise OTP::InvalidOTPError, "Received error: #{@status}"

--- a/spec/yubikey/otp_verify_spec.rb
+++ b/spec/yubikey/otp_verify_spec.rb
@@ -56,6 +56,14 @@ describe 'Yubikey::OTP::Verify' do
     expect{ Yubikey::OTP::Verify.new({:api_id => 'foo'}) }.to raise_error(ArgumentError, "Must supply API Key")
   end
 
+  it 'should parse the otp from the response' do
+    ok_response = "#{@response}status=OK"
+    hmac = Yubikey::OTP::Verify::generate_hmac(ok_response, @key)
+    @mock_http_get.should_receive(:body).and_return("h=#{hmac}\n#{ok_response}")
+    verify = Yubikey::OTP::Verify.new(:api_id => @id, :api_key => @key, :otp => @otp, :nonce => @nonce)
+    verify.otp.should == @otp
+  end
+
   context "with module configuration" do
     before do
       Yubikey.configure do |config|


### PR DESCRIPTION
This allow clients to handle yubikeys on DVORAK environments,
where the code entered by the yubikey is actually converted by
their API.
